### PR TITLE
Fix open() of BLE Adaptor

### DIFF
--- a/lib/adaptors/ble.js
+++ b/lib/adaptors/ble.js
@@ -83,12 +83,14 @@ Adaptor.prototype.open = function open(callback) {
     self._connectPeripheral(this.noblePeripheral, callback);
   } else {
     // connect to peripheral using noble
-    ble.on("discover", function(peripheral) {
+    var discoverCallback = function(peripheral) {
       if (peripheral.id === self.uuid) {
         ble.stopScanning();
+        ble.removeListener("discover", discoverCallback);
         self._connectPeripheral(peripheral, callback);
       }
-    });
+    }
+    ble.on("discover", discoverCallback);
 
     if (ble.state === "poweredOn") {
       ble.startScanning();


### PR DESCRIPTION
Adaptor.open()で接続処理をnobleのdiscoverイベントに登録しているが、接続後もそのままなので、disconnect後に再度connectすると重複してイベントハンドラが登録されてしまう。